### PR TITLE
Works with Special Characters now

### DIFF
--- a/Recycle/Recycle.psm1
+++ b/Recycle/Recycle.psm1
@@ -90,10 +90,10 @@ function Remove-ItemSafely {
 }
 
 function Recycle-Item($Path) {
-    $item = Get-Item $Path
+    $item = Get-Item -LiteralPath $Path
     $directoryPath = Split-Path $item -Parent
     
-    $shell = new-object -comobject "Shell.Application"
+    $shell = New-Object -ComObject "Shell.Application"
     $shellFolder = $shell.Namespace($directoryPath)
     $shellItem = $shellFolder.ParseName($item.Name)
     $shellItem.InvokeVerb("delete")


### PR DESCRIPTION
This is my pull request to my issue #2 .

If I change Line 93 in `Recycle.psm1` to ` $item = Get-Item -LiteralPath $Path`, my script works, and at least it seems that console-inputs still work, too.